### PR TITLE
contrib/widget-examples/{dwm,i3}/xkb.lua some improvement

### DIFF
--- a/contrib/widget-examples/dwm/xkb.lua
+++ b/contrib/widget-examples/dwm/xkb.lua
@@ -1,12 +1,17 @@
 widget = {
     plugin = 'xkb',
     cb = function(t)
-        if t.name == 'us' then
-            return '[En]'
-        elseif t.name == 'ru(winkeys)' then
-            return '[Ru]'
+        if t.name then
+            local base_layout = t.name:match('[^(]+')
+            if base_layout == 'gb' or base_layout == 'us' then
+                return '[En]'
+            elseif base_layout == 'ru' then
+                return '[Ru]'
+            else
+                return '[' .. base_layout:sub(1,1):upper() .. base_layout:sub(2) .. ']'
+            end
         else
-            return '[' .. (t.name or '? ID ' .. t.id) .. ']'
+            return '[' .. '? ID ' .. t.id .. ']'
         end
     end,
 }

--- a/contrib/widget-examples/i3/xkb.lua
+++ b/contrib/widget-examples/i3/xkb.lua
@@ -1,12 +1,17 @@
 widget = {
     plugin = 'xkb',
     cb = function(t)
-        if t.name == 'us' then
-            return {full_text = '[En]', color = '#9c9c9c'}
-        elseif t.name == 'ru(winkeys)' then
-            return {full_text = '[Ru]', color = '#eab93d'}
+        if t.name then
+            local base_layout = t.name:match('[^(]+')
+            if base_layout == 'gb' or base_layout == 'us' then
+                return {full_text = '[En]', color = '#9c9c9c'}
+            elseif base_layout == 'ru' then
+                return {full_text = '[Ru]', color = '#eab93d'}
+            else
+                return {full_text = '[' .. base_layout:sub(1,1):upper() .. base_layout:sub(2) .. ']'}
+            end
         else
-            return {full_text = '[' .. (t.name or '? ID ' .. t.id) .. ']'}
+            return {full_text = '[' .. '? ID ' .. t.id .. ']'}
         end
     end,
 }


### PR DESCRIPTION
1. Now xkb.lua works properly with different variants english and russian layouts. Forexample
ru, ru(winkeys), etc. layouts displayed as Ru
gb, gb(dvorak), etc. layouts displayed as En
us, us(dvorak), etc. layouts displayed as En
Previously, 'ru' layout was displayed as 'ru', not as 'Ru'

2. For other layouts first character now also displayed in upper case