### PR TITLE
Check that 'fifo' is really a FIFO

### DIFF
--- a/libls/evloop_utils.h
+++ b/libls/evloop_utils.h
@@ -153,6 +153,7 @@ ls_wakeup_fifo_init(LSWakeupFifo *w, const char *fifo, sigset_t *sigmask);
 // it.
 //
 // On success, /0/ is returned; on failure, /-1/ is returned and /errno/ is set.
+// /errno/ equals /-EINVAL/ if the file is not a FIFO.
 int
 ls_wakeup_fifo_open(LSWakeupFifo *w);
 

--- a/plugins/fs/fs.c
+++ b/plugins/fs/fs.c
@@ -147,7 +147,8 @@ run(LuastatusPluginData *pd, LuastatusPluginRunFuncs funcs)
         funcs.call_end(pd->userdata);
         // wait
         if (ls_wakeup_fifo_open(&w) < 0) {
-            LS_WARNF(pd, "ls_wakeup_fifo_open: %s: %s", p->fifo, ls_strerror_onstack(errno));
+            LS_WARNF(pd, "ls_wakeup_fifo_open: %s: %s", p->fifo,
+                errno == -EINVAL ? "The file is not a FIFO" : ls_strerror_onstack(errno));
         }
         if (ls_wakeup_fifo_wait(&w, p->period) < 0) {
             LS_FATALF(pd, "ls_wakeup_fifo_wait: %s: %s", p->fifo, ls_strerror_onstack(errno));

--- a/plugins/mpd/mpd.c
+++ b/plugins/mpd/mpd.c
@@ -360,7 +360,8 @@ run(LuastatusPluginData *pd, LuastatusPluginRunFuncs funcs)
         report_status(pd, funcs, "error");
 
         if (ls_wakeup_fifo_open(&w) < 0) {
-            LS_WARNF(pd, "ls_wakeup_fifo_open: %s: %s", p->retry_fifo, ls_strerror_onstack(errno));
+            LS_WARNF(pd, "ls_wakeup_fifo_open: %s: %s", p->retry_fifo,
+                errno == -EINVAL ? "The file is not a FIFO" : ls_strerror_onstack(errno));
         }
         if (ls_wakeup_fifo_wait(&w, p->retry_in) < 0) {
             LS_FATALF(pd, "ls_wakeup_fifo_wait: %s: %s", p->retry_fifo, ls_strerror_onstack(errno));

--- a/plugins/timer/timer.c
+++ b/plugins/timer/timer.c
@@ -85,7 +85,8 @@ run(LuastatusPluginData *pd, LuastatusPluginRunFuncs funcs)
         funcs.call_end(pd->userdata);
 
         if (ls_wakeup_fifo_open(&w) < 0) {
-            LS_WARNF(pd, "ls_wakeup_fifo_open: %s: %s", p->fifo, ls_strerror_onstack(errno));
+            LS_WARNF(pd, "ls_wakeup_fifo_open: %s: %s", p->fifo,
+                errno == -EINVAL ? "The file is not a FIFO" : ls_strerror_onstack(errno));
         }
         int r = ls_wakeup_fifo_wait(&w, ls_pushed_timeout_fetch(&p->pushed_timeout, p->period));
         if (r < 0) {


### PR DESCRIPTION
Fixes the bug that if 'fifo' is a regular file then luastatus hangs in a loop.