### PR TITLE
Reduce the number of options of the `battery-linux` plugin

### DIFF
--- a/DEPENDS.txt
+++ b/DEPENDS.txt
@@ -20,7 +20,7 @@ Plugin 'backlight-linux' has the following dependencies:
 * plugin 'udev'
 
 Plugin 'battery-linux' has the following dependencies:
-* plugin 'timer'
+* plugin 'udev'
 
 Plugin 'cpu-usage-linux' has the following dependencies:
 * plugin 'timer'

--- a/contrib/luastatus-9999.ebuild
+++ b/contrib/luastatus-9999.ebuild
@@ -59,7 +59,7 @@ SLOT="0"
 IUSE="doc examples luajit ${BARLIBS} ${PLUGINS}"
 REQUIRED_USE="
 	${PN}_plugins_backlight-linux? ( ${PN}_plugins_udev )
-	${PN}_plugins_battery-linux? ( ${PN}_plugins_timer )
+	${PN}_plugins_battery-linux? ( ${PN}_plugins_udev )
 	${PN}_plugins_cpu-usage-linux? ( ${PN}_plugins_timer )
 	${PN}_plugins_file-contents-linux? ( ${PN}_plugins_inotify )
 	${PN}_plugins_imap? ( ${PN}_plugins_timer )

--- a/examples/dwm/battery.lua
+++ b/examples/dwm/battery.lua
@@ -1,6 +1,5 @@
 widget = luastatus.require_plugin('battery-linux').widget{
-    est_rem_time = true,
-    timer_opts = {period = 2},
+    period = 2,
     cb = function(t)
         local symbol = ({
             Charging    = '↑',
@@ -13,7 +12,7 @@ widget = luastatus.require_plugin('battery-linux').widget{
             rem_seg = string.format('%2dh %02dm', h, m)
         end
         return {
-            string.format('%3s%%%s', t.capacity, symbol),
+            string.format('%3d%%%s', t.capacity, symbol),
             rem_seg,
         }
     end,

--- a/examples/dwm/time-battery-combined.lua
+++ b/examples/dwm/time-battery-combined.lua
@@ -1,6 +1,4 @@
-bat = luastatus.require_plugin('battery-linux')
-function get_bat_seg()
-    local t = bat.read_uevent('BAT0')
+function get_bat_seg(t)
     if not t then
         return '[--×--]'
     end
@@ -13,16 +11,15 @@ function get_bat_seg()
     elseif t.status == 'Charging' then
         sym = '↑'
     end
-    return string.format('[%3s%%%s]', t.capacity, sym)
+    return string.format('[%3d%%%s]', t.capacity, sym)
 end
 
-widget = {
-    plugin = 'timer',
-    opts = {period = 2},
-    cb = function()
+widget = luastatus.require_plugin('battery-linux').widget{
+    period = 2,
+    cb = function(t)
         return {
             os.date('[%H:%M]'),
-            get_bat_seg(),
+            get_bat_seg(t),
         }
     end,
 }

--- a/examples/i3/battery.lua
+++ b/examples/i3/battery.lua
@@ -1,6 +1,5 @@
 widget = luastatus.require_plugin('battery-linux').widget{
-    est_rem_time = true,
-    timer_opts = {period = 2},
+    period = 2,
     cb = function(t)
         local symbol = ({
             Charging    = '↑',
@@ -13,7 +12,7 @@ widget = luastatus.require_plugin('battery-linux').widget{
             rem_seg = {full_text = string.format('%2dh %02dm', h, m), color = '#595959'}
         end
         return {
-            {full_text = string.format('%3s%%%s', t.capacity, symbol)},
+            {full_text = string.format('%3d%%%s', t.capacity, symbol)},
             rem_seg,
         }
     end,

--- a/examples/i3/time-battery-combined.lua
+++ b/examples/i3/time-battery-combined.lua
@@ -1,6 +1,5 @@
 bat = luastatus.require_plugin('battery-linux')
-function get_bat_seg()
-    local t = bat.read_uevent('BAT0')
+function get_bat_seg(t)
     if not t then
         return {full_text = '[--×--]'}
     end
@@ -15,16 +14,15 @@ function get_bat_seg()
         sym = '↑'
         color = '#60b48a'
     end
-    return {full_text = string.format('[%3s%%%s]', t.capacity, sym), color = color}
+    return {full_text = string.format('[%3d%%%s]', t.capacity, sym), color = color}
 end
 
-widget = {
-    plugin = 'timer',
-    opts = {period = 2},
-    cb = function()
+widget = luastatus.require_plugin('battery-linux').widget{
+    period = 2,
+    cb = function(t)
         return {
             {full_text = os.date('[%H:%M]'), color = '#dc8cc3'},
-            get_bat_seg(),
+            get_bat_seg(t),
         }
     end,
 }

--- a/plugins/battery-linux/README.rst
+++ b/plugins/battery-linux/README.rst
@@ -12,65 +12,12 @@ Overview
 ========
 This derived plugin periodically polls Linux ``sysfs`` for the state of a battery.
 
-It is also able to estimate the time remaining to full charge/discharge.
-
-Property naming schemes
-=======================
-Linux has once changed its naming scheme of some files in ``/sys/class/power_supply/<device>/``.
-Changes include:
-
-* ``charge_full`` renamed to ``energy_full``;
-
-* ``charge_now`` renamed to ``energy_now``;
-
-* ``current_now`` renamed to ``power_now``.
-
-By default, this plugin uses the "new" naming scheme; to change that, call
-``B.use_props_naming_scheme("old")``, where ``B`` is the module object.
+It is also able to estimate the time remaining to full charge/discharge and
+the current battery consumption rate.
 
 Functions
 =========
 The following functions are provided:
-
-* ``read_uevent(device)``
-
-    Reads a key-value table from ``/sys/class/power_supply/<device>/uevent``.
-
-    If it cannot be read, returns ``nil``.
-
-* ``read_files(device, proplist)``
-
-    Reads a key-value pairs from ``/sys/class/power_supply/<device>/<prop>`` for each ``<prop>`` in
-    ``proplist``.
-
-    If a property cannot be read, it is not included to the resulting table.
-
-* ``use_props_naming_scheme(name)``
-
-    Tells the module which property naming scheme to use; ``name`` is either ``"old"`` or ``"new"``.
-
-* ``get_props_naming_scheme()``
-
-    Returns a table representing the current property naming scheme. It has the following keys:
-
-    - ``EF``: either ``"charge_full"`` or ``"energy_full"``;
-
-    - ``EN``: either ``"charge_now"`` or ``"energy_now"``;
-
-    - ``PN``: either ``"current_now"`` or ``"power_now"``.
-
-* ``est_rem_time(props)``
-
-    Estimates the time in hours remaining to full charge/discharge. ``props`` is a table with
-    following keys (assuming ``S`` is a table returned by ``get_props_naming_scheme()``):
-
-    * ``"status"``;
-
-    * ``S.EF``;
-
-    * ``S.EN``;
-
-    * ``S.PN``.
 
 * ``widget(tbl)``
 
@@ -88,43 +35,39 @@ The following functions are provided:
             A string with battery status text, e.g. ``"Full"``, ``"Unknown"``, ``"Charging"``,
             ``"Discharging"``.
 
-            Not present if the status cannot be read.
+            Not present if the status cannot be read (for example, when the battery is missing).
 
-        + ``capacity``: string
+        + ``capacity``: number
 
-            A string representing battery capacity percent.
+            A percentage representing battery capacity.
 
             Not present if the capacity cannot be read.
 
         + ``rem_time``: number
 
-            If applicable, time (usually in hours) remaining to full charge/discharge.
+            Time (in hours) remaining to full charge/discharge.
 
-            (Only present if the ``est_rem_time`` option was set to ``true``.)
+            Usually only present on battery charge/discharge.
+
+        + ``consumption``: number
+
+            The current battery consumption/charge rate in watts.
+
+            Usually only present on battery charge/discharge.
 
     **(optional)**
 
     - ``dev``: string
 
-        Device directory name; default is ``"BAT0"``.
+        Device directory name under ``/sys/class/power_supply``; default is ``"BAT0"``.
 
-    - ``no_uevent``: boolean
+    - ``period``: number
 
-        If ``true``, data will be read from individual property files, not from the ``uevent``
-        file.
+        The period in seconds for polling ``sysfs``; default is 2 seconds.
 
-    - ``props_naming_scheme``: string
-
-        If present, ``use_props_naming_scheme`` will be called with it before anything else is done.
-
-    - ``est_rem_time``: boolean
-
-        If ``true``, time remaining to full charge/discharge will be estimated and passed to
-        ``cb`` as ``rem_time`` table entry.
-
-    - ``timer_opts``: table
-
-        Options for the underlying ``timer`` plugin.
+        Because this plugin utilizes ``udev`` under the hood, it is able to respond to
+        battery state changes (such as cable (un-)plugging) immediately, irrespective of
+        the value of the period.
 
     - ``event``
 

--- a/plugins/battery-linux/battery-linux.lua
+++ b/plugins/battery-linux/battery-linux.lua
@@ -1,6 +1,6 @@
 local P = {}
 
-function P.read_uevent(dev)
+local function read_uevent(dev)
     local f = io.open('/sys/class/power_supply/' .. dev .. '/uevent', 'r')
     if not f then
         return nil
@@ -14,83 +14,48 @@ function P.read_uevent(dev)
     return r
 end
 
-function P.read_files(dev, proplist)
-    local prefix = '/sys/class/power_supply/' .. dev .. '/'
-    local r = {}
-    for _, prop in ipairs(proplist) do
-        local f = io.open(prefix .. prop, 'r')
-        if f then
-            r[prop] = f:read('*line')
-            f:close()
+local function get_battery_info(dev)
+    local p = read_uevent(dev)
+    if not p then
+        return {}
+    end
+
+    -- Convert amperes to watts.
+    if p.charge_full then
+        p.energy_full = p.charge_full * p.voltage_now / 1e6
+        p.energy_now = p.charge_now * p.voltage_now / 1e6
+        p.power_now = p.current_now * p.voltage_now / 1e6
+    end
+
+    local r = {status = p.status}
+    -- A buggy driver can report energy_now as energy_full_design, which
+    -- will lead to an overshoot in capacity.
+    r.capacity = math.min(math.floor(p.energy_now / p.energy_full * 100 + 0.5), 100)
+
+    if p.power_now ~= 0 then
+        r.consumption = p.power_now / 1e6
+        if p.status == 'Charging' then
+            r.rem_time = (p.energy_full - p.energy_now) / p.power_now
+        elseif p.status == 'Discharging' then
+            r.rem_time = p.energy_now / p.power_now
         end
     end
+
     return r
 end
 
-local PROPS_NAMING_SCHEMAS = {
-    new = {
-        EF = 'energy_full',
-        EN = 'energy_now',
-        PN = 'power_now',
-    },
-    old = {
-        EF = 'charge_full',
-        EN = 'charge_now',
-        PN = 'current_now',
-    },
-}
-local pns = PROPS_NAMING_SCHEMAS.new
-function P.use_props_naming_scheme(name)
-    pns = assert(PROPS_NAMING_SCHEMAS[name])
-end
-function P.get_props_naming_scheme()
-    return pns
-end
-
-function P.est_rem_time(props)
-    local ef, en, pn = props[pns.EF], props[pns.EN], props[pns.PN]
-    if (not ef) or (not en) or (not pn or pn == 0) then
-        return nil
-    end
-    if props.status == 'Charging' then
-        return (ef - en) / pn
-    elseif props.status == 'Discharging' then
-        return en / pn
-    else
-        return nil
-    end
-end
-
 function P.widget(tbl)
-    if tbl.props_naming_scheme then
-        P.use_props_naming_scheme(tbl.props_naming_scheme)
-    end
     local dev = tbl.dev or 'BAT0'
-    local read_props
-    if tbl.no_uevent then
-        local proplist = {'status', 'capacity'}
-        if tbl.est_rem_time then
-            table.insert(proplist, pns.EF)
-            table.insert(proplist, pns.EN)
-            table.insert(proplist, pns.PN)
-        end
-        read_props = function()
-            return P.read_files(dev, proplist)
-        end
-    else
-        read_props = function()
-            return P.read_uevent(dev)
-        end
-    end
+    local period = tbl.period or 2
     return {
-        plugin = 'timer',
-        opts = tbl.timer_opts,
+        plugin = 'udev',
+        opts = {
+            subsystem = 'power_supply',
+            timeout = period,
+            greet = true
+        },
         cb = function()
-            local t = read_props()
-            if tbl.est_rem_time then
-                t.rem_time = P.est_rem_time(t)
-            end
-            return tbl.cb(t)
+            return tbl.cb(get_battery_info(dev))
         end,
         event = tbl.event,
     }


### PR DESCRIPTION
The plugin exposed too much of its implementation details to the user.
Some of the options were very specific to the platform on which the
plugin is running, but which could be dealt with without user
intervention.

The changes are as follows:

1. The underlying implementation is backed by udev now, so that
   plugging/unplugging events are displayed immediately.

2. The property naming schemas are removed. We can determine the units
   when the battery becomes available (thanks to udev).

3. No global variables used.

4. Add the `consumption` field to the returned table. The values is
   always in Watts irrespective of the units used in the underlying
   driver. This is what i3status does. And I think it is a good way to
   abstract away such minor platform differences.

5. The file `capacity` is not parsed. Instead the ratio of `energy_now`
   to `energy_full` is used. I also plan to add an option to calculate
   the capacity relative to `energy_full_design` (in which case the
   `capacity` file is useless anyway).

6. All necessary files are unconditionally read. And the estimated
   remaining time is always calculated (if it can be). The overhead of
   computing it is so small that it doesn't make a difference.

7. The option `period` is added and the `timer_opts` is removed.

8. Some obsolete options and functions are removed.

I did some benchmarks. The new version is about as fast as the old
version with `no_uevent` set, which is 50% slower than the uevent
version. The time for computing battery stats is around 80 microseconds
on my rather average machine. Given that the default polling period is
set to 2 seconds, this results in occupying 0.004% of the whole CPU
time (on one core).