### PR TITLE
pulse plugin: provide more parameters

### DIFF
--- a/plugins/pulse/README.rst
+++ b/plugins/pulse/README.rst
@@ -44,6 +44,77 @@ The following options are supported:
 
       Whether the sink is mute.
 
+  - ``index``: integer
+
+      Index of the default sink.
+
+  - ``name``: string
+
+      Name of the default sink.
+
+  - ``desc``: string
+
+      Description of the default sink.
+
+  - ``port_name``: string
+
+      Name of the default sink's active port.
+
+  - ``port_desc``: string
+
+      Description of the default sink's active port.
+
+  - ``port_type``: string
+
+      Type of the default sink's active port.
+      Possible values are:
+
+      - ``"unknown"``
+
+      - ``"aux"``
+
+      - ``"speaker"``
+
+      - ``"headphones"``
+
+      - ``"line"``
+
+      - ``"mic"``
+
+      - ``"headset"``
+
+      - ``"handset"``
+
+      - ``"earpiece"``
+
+      - ``"spdif"``
+
+      - ``"hdmi"``
+
+      - ``"tv"``
+
+      - ``"radio"``
+
+      - ``"video"``
+
+      - ``"usb"``
+
+      - ``"bluetooth"``
+
+      - ``"portable"``
+
+      - ``"handsfree"``
+
+      - ``"car"``
+
+      - ``"hifi"``
+
+      - ``"phone"``
+
+      - ``"network"``
+
+      - ``"analog"``
+
 Functions
 =========
 The following functions are provided:

--- a/plugins/pulse/README.rst
+++ b/plugins/pulse/README.rst
@@ -56,64 +56,66 @@ The following options are supported:
 
       Description of the default sink.
 
-  - ``port_name``: string
+  - ``port``: table with following entries, or ``nil`` if there is no active port:
 
-      Name of the default sink's active port.
+      - ``name``: string
 
-  - ``port_desc``: string
+          Name of the default sink's active port.
 
-      Description of the default sink's active port.
+      - ``desc``: string
 
-  - ``port_type``: string
+          Description of the default sink's active port.
 
-      Type of the default sink's active port.
-      Possible values are:
+      - ``type``: string
 
-      - ``"unknown"``
+          Type of the default sink's active port.
+          Possible values are:
 
-      - ``"aux"``
+          - ``"unknown"``
 
-      - ``"speaker"``
+          - ``"aux"``
 
-      - ``"headphones"``
+          - ``"speaker"``
 
-      - ``"line"``
+          - ``"headphones"``
 
-      - ``"mic"``
+          - ``"line"``
 
-      - ``"headset"``
+          - ``"mic"``
 
-      - ``"handset"``
+          - ``"headset"``
 
-      - ``"earpiece"``
+          - ``"handset"``
 
-      - ``"spdif"``
+          - ``"earpiece"``
 
-      - ``"hdmi"``
+          - ``"spdif"``
 
-      - ``"tv"``
+          - ``"hdmi"``
 
-      - ``"radio"``
+          - ``"tv"``
 
-      - ``"video"``
+          - ``"radio"``
 
-      - ``"usb"``
+          - ``"video"``
 
-      - ``"bluetooth"``
+          - ``"usb"``
 
-      - ``"portable"``
+          - ``"bluetooth"``
 
-      - ``"handsfree"``
+          - ``"portable"``
 
-      - ``"car"``
+          - ``"handsfree"``
 
-      - ``"hifi"``
+          - ``"car"``
 
-      - ``"phone"``
+          - ``"hifi"``
 
-      - ``"network"``
+          - ``"phone"``
 
-      - ``"analog"``
+          - ``"network"``
+
+          - ``"analog"``
 
 Functions
 =========

--- a/plugins/pulse/pulse.c
+++ b/plugins/pulse/pulse.c
@@ -127,6 +127,36 @@ static void self_pipe_cb(
     ud->funcs.call_end(ud->pd->userdata);
 }
 
+static void push_port_type(lua_State *L, int type)
+{
+    switch (type) {
+    default:                              lua_pushstring(L, "unknown"); break;
+    case PA_DEVICE_PORT_TYPE_UNKNOWN:     lua_pushstring(L, "unknown"); break;
+    case PA_DEVICE_PORT_TYPE_AUX:         lua_pushstring(L, "aux"); break;
+    case PA_DEVICE_PORT_TYPE_SPEAKER:     lua_pushstring(L, "speaker"); break;
+    case PA_DEVICE_PORT_TYPE_HEADPHONES:  lua_pushstring(L, "headphones"); break;
+    case PA_DEVICE_PORT_TYPE_LINE:        lua_pushstring(L, "line"); break;
+    case PA_DEVICE_PORT_TYPE_MIC:         lua_pushstring(L, "mic"); break;
+    case PA_DEVICE_PORT_TYPE_HEADSET:     lua_pushstring(L, "headset"); break;
+    case PA_DEVICE_PORT_TYPE_HANDSET:     lua_pushstring(L, "handset"); break;
+    case PA_DEVICE_PORT_TYPE_EARPIECE:    lua_pushstring(L, "earpiece"); break;
+    case PA_DEVICE_PORT_TYPE_SPDIF:       lua_pushstring(L, "spdif"); break;
+    case PA_DEVICE_PORT_TYPE_HDMI:        lua_pushstring(L, "hdmi"); break;
+    case PA_DEVICE_PORT_TYPE_TV:          lua_pushstring(L, "tv"); break;
+    case PA_DEVICE_PORT_TYPE_RADIO:       lua_pushstring(L, "radio"); break;
+    case PA_DEVICE_PORT_TYPE_VIDEO:       lua_pushstring(L, "video"); break;
+    case PA_DEVICE_PORT_TYPE_USB:         lua_pushstring(L, "usb"); break;
+    case PA_DEVICE_PORT_TYPE_BLUETOOTH:   lua_pushstring(L, "bluetooth"); break;
+    case PA_DEVICE_PORT_TYPE_PORTABLE:    lua_pushstring(L, "portable"); break;
+    case PA_DEVICE_PORT_TYPE_HANDSFREE:   lua_pushstring(L, "handsfree"); break;
+    case PA_DEVICE_PORT_TYPE_CAR:         lua_pushstring(L, "car"); break;
+    case PA_DEVICE_PORT_TYPE_HIFI:        lua_pushstring(L, "hifi"); break;
+    case PA_DEVICE_PORT_TYPE_PHONE:       lua_pushstring(L, "phone"); break;
+    case PA_DEVICE_PORT_TYPE_NETWORK:     lua_pushstring(L, "network"); break;
+    case PA_DEVICE_PORT_TYPE_ANALOG:      lua_pushstring(L, "analog"); break;
+    }
+}
+
 static void store_volume_from_sink_cb(
         pa_context *c,
         const pa_sink_info *info,
@@ -160,34 +190,7 @@ static void store_volume_from_sink_cb(
             lua_setfield(L, -2, "port_name"); // L: ? table
             lua_pushstring(L, info->active_port->description); // L: ? table string
             lua_setfield(L, -2, "port_desc"); // L: ? table
-            switch (info->active_port->type) {
-            case PA_DEVICE_PORT_TYPE_UNKNOWN:     lua_pushstring(L, "unknown"); break;
-            case PA_DEVICE_PORT_TYPE_AUX:         lua_pushstring(L, "aux"); break;
-            case PA_DEVICE_PORT_TYPE_SPEAKER:     lua_pushstring(L, "speaker"); break;
-            case PA_DEVICE_PORT_TYPE_HEADPHONES:  lua_pushstring(L, "headphones"); break;
-            case PA_DEVICE_PORT_TYPE_LINE:        lua_pushstring(L, "line"); break;
-            case PA_DEVICE_PORT_TYPE_MIC:         lua_pushstring(L, "mic"); break;
-            case PA_DEVICE_PORT_TYPE_HEADSET:     lua_pushstring(L, "headset"); break;
-            case PA_DEVICE_PORT_TYPE_HANDSET:     lua_pushstring(L, "handset"); break;
-            case PA_DEVICE_PORT_TYPE_EARPIECE:    lua_pushstring(L, "earpiece"); break;
-            case PA_DEVICE_PORT_TYPE_SPDIF:       lua_pushstring(L, "spdif"); break;
-            case PA_DEVICE_PORT_TYPE_HDMI:        lua_pushstring(L, "hdmi"); break;
-            case PA_DEVICE_PORT_TYPE_TV:          lua_pushstring(L, "tv"); break;
-            case PA_DEVICE_PORT_TYPE_RADIO:       lua_pushstring(L, "radio"); break;
-            case PA_DEVICE_PORT_TYPE_VIDEO:       lua_pushstring(L, "video"); break;
-            case PA_DEVICE_PORT_TYPE_USB:         lua_pushstring(L, "usb"); break;
-            case PA_DEVICE_PORT_TYPE_BLUETOOTH:   lua_pushstring(L, "bluetooth"); break;
-            case PA_DEVICE_PORT_TYPE_PORTABLE:    lua_pushstring(L, "portable"); break;
-            case PA_DEVICE_PORT_TYPE_HANDSFREE:   lua_pushstring(L, "handsfree"); break;
-            case PA_DEVICE_PORT_TYPE_CAR:         lua_pushstring(L, "car"); break;
-            case PA_DEVICE_PORT_TYPE_HIFI:        lua_pushstring(L, "hifi"); break;
-            case PA_DEVICE_PORT_TYPE_PHONE:       lua_pushstring(L, "phone"); break;
-            case PA_DEVICE_PORT_TYPE_NETWORK:     lua_pushstring(L, "network"); break;
-            case PA_DEVICE_PORT_TYPE_ANALOG:      lua_pushstring(L, "analog"); break;
-            default:
-                lua_pushstring(L, "unknown");
-                break;
-            }
+            push_port_type(L, info->active_port->type); // L: ? table string
             lua_setfield(L, -2, "port_type"); // L: ? table
             ud->funcs.call_end(ud->pd->userdata);
         }

--- a/plugins/pulse/pulse.c
+++ b/plugins/pulse/pulse.c
@@ -143,13 +143,52 @@ static void store_volume_from_sink_cb(
         if (info->index == ud->sink_idx) {
             lua_State *L = ud->funcs.call_begin(ud->pd->userdata);
             // L: ?
-            lua_createtable(L, 0, 3); // L: ? table
+            lua_createtable(L, 0, 9); // L: ? table
             lua_pushinteger(L, pa_cvolume_avg(&info->volume)); // L: ? table integer
             lua_setfield(L, -2, "cur"); // L: ? table
             lua_pushinteger(L, PA_VOLUME_NORM); // L: ? table integer
             lua_setfield(L, -2, "norm"); // L: ? table
             lua_pushboolean(L, info->mute); // L: ? table boolean
             lua_setfield(L, -2, "mute"); // L: ? table
+            lua_pushinteger(L, info->index); // L: ? table integer
+            lua_setfield(L, -2, "index"); // L: ? table
+            lua_pushstring(L, info->name); // L: ? table string
+            lua_setfield(L, -2, "name"); // L: ? table
+            lua_pushstring(L, info->description); // L: ? table string
+            lua_setfield(L, -2, "desc"); // L: ? table
+            lua_pushstring(L, info->active_port->name); // L: ? table string
+            lua_setfield(L, -2, "port_name"); // L: ? table
+            lua_pushstring(L, info->active_port->description); // L: ? table string
+            lua_setfield(L, -2, "port_desc"); // L: ? table
+            switch (info->active_port->type) {
+            case PA_DEVICE_PORT_TYPE_UNKNOWN:     lua_pushstring(L, "unknown"); break;
+            case PA_DEVICE_PORT_TYPE_AUX:         lua_pushstring(L, "aux"); break;
+            case PA_DEVICE_PORT_TYPE_SPEAKER:     lua_pushstring(L, "speaker"); break;
+            case PA_DEVICE_PORT_TYPE_HEADPHONES:  lua_pushstring(L, "headphones"); break;
+            case PA_DEVICE_PORT_TYPE_LINE:        lua_pushstring(L, "line"); break;
+            case PA_DEVICE_PORT_TYPE_MIC:         lua_pushstring(L, "mic"); break;
+            case PA_DEVICE_PORT_TYPE_HEADSET:     lua_pushstring(L, "headset"); break;
+            case PA_DEVICE_PORT_TYPE_HANDSET:     lua_pushstring(L, "handset"); break;
+            case PA_DEVICE_PORT_TYPE_EARPIECE:    lua_pushstring(L, "earpiece"); break;
+            case PA_DEVICE_PORT_TYPE_SPDIF:       lua_pushstring(L, "spdif"); break;
+            case PA_DEVICE_PORT_TYPE_HDMI:        lua_pushstring(L, "hdmi"); break;
+            case PA_DEVICE_PORT_TYPE_TV:          lua_pushstring(L, "tv"); break;
+            case PA_DEVICE_PORT_TYPE_RADIO:       lua_pushstring(L, "radio"); break;
+            case PA_DEVICE_PORT_TYPE_VIDEO:       lua_pushstring(L, "video"); break;
+            case PA_DEVICE_PORT_TYPE_USB:         lua_pushstring(L, "usb"); break;
+            case PA_DEVICE_PORT_TYPE_BLUETOOTH:   lua_pushstring(L, "bluetooth"); break;
+            case PA_DEVICE_PORT_TYPE_PORTABLE:    lua_pushstring(L, "portable"); break;
+            case PA_DEVICE_PORT_TYPE_HANDSFREE:   lua_pushstring(L, "handsfree"); break;
+            case PA_DEVICE_PORT_TYPE_CAR:         lua_pushstring(L, "car"); break;
+            case PA_DEVICE_PORT_TYPE_HIFI:        lua_pushstring(L, "hifi"); break;
+            case PA_DEVICE_PORT_TYPE_PHONE:       lua_pushstring(L, "phone"); break;
+            case PA_DEVICE_PORT_TYPE_NETWORK:     lua_pushstring(L, "network"); break;
+            case PA_DEVICE_PORT_TYPE_ANALOG:      lua_pushstring(L, "analog"); break;
+            default:
+                lua_pushstring(L, "unknown");
+                break;
+            }
+            lua_setfield(L, -2, "port_type"); // L: ? table
             ud->funcs.call_end(ud->pd->userdata);
         }
     }

--- a/plugins/pulse/pulse.c
+++ b/plugins/pulse/pulse.c
@@ -173,7 +173,7 @@ static void store_volume_from_sink_cb(
         if (info->index == ud->sink_idx) {
             lua_State *L = ud->funcs.call_begin(ud->pd->userdata);
             // L: ?
-            lua_createtable(L, 0, 9); // L: ? table
+            lua_createtable(L, 0, 7); // L: ? table
             lua_pushinteger(L, pa_cvolume_avg(&info->volume)); // L: ? table integer
             lua_setfield(L, -2, "cur"); // L: ? table
             lua_pushinteger(L, PA_VOLUME_NORM); // L: ? table integer
@@ -186,12 +186,18 @@ static void store_volume_from_sink_cb(
             lua_setfield(L, -2, "name"); // L: ? table
             lua_pushstring(L, info->description); // L: ? table string
             lua_setfield(L, -2, "desc"); // L: ? table
-            lua_pushstring(L, info->active_port->name); // L: ? table string
-            lua_setfield(L, -2, "port_name"); // L: ? table
-            lua_pushstring(L, info->active_port->description); // L: ? table string
-            lua_setfield(L, -2, "port_desc"); // L: ? table
-            push_port_type(L, info->active_port->type); // L: ? table string
-            lua_setfield(L, -2, "port_type"); // L: ? table
+            if (!info->active_port) {
+                lua_pushnil(L); // L: ? table nil
+            } else {
+                lua_createtable(L, 0, 3); // L: ? table table
+                lua_pushstring(L, info->active_port->name); // L: ? table table string
+                lua_setfield(L, -2, "name"); // L: ? table table
+                lua_pushstring(L, info->active_port->description); // L: ? table table string
+                lua_setfield(L, -2, "desc"); // L: ? table table
+                push_port_type(L, info->active_port->type); // L: ? table table string
+                lua_setfield(L, -2, "type"); // L: ? table table
+            }
+            lua_setfield(L, -2, "port"); // L: ? table
             ud->funcs.call_end(ud->pd->userdata);
         }
     }


### PR DESCRIPTION
Output more pulseaudio sink parameters.
These params help widgets determine the type of the active sink and it's active port.