### PR TITLE
update gentoo ebuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ include (GNUInstallDirs)
 
 set (BARLIBS_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/luastatus/barlibs")
 set (PLUGINS_DIR "${CMAKE_INSTALL_FULL_LIBDIR}/luastatus/plugins")
-set (LUA_PLUGINS_DIR "${CMAKE_INSTALL_FULL_DATAROOTDIR}/luastatus/plugins")
+set (CACHE LUA_PLUGINS_DIR "${CMAKE_INSTALL_FULL_DATAROOTDIR}/luastatus/plugins")
 
 function (luastatus_add_barlib_or_plugin destdir name)
     set (sources ${ARGV})

--- a/contrib/luastatus-9999.ebuild
+++ b/contrib/luastatus-9999.ebuild
@@ -1,133 +1,110 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
-CMAKE_IN_SOURCE_BUILD=1
-inherit cmake
+
+# to find config.generated.h
+CMAKE_IN_SOURCE_BUILD=true
+LUA_COMPAT=( lua5-{1..4} luajit )
+inherit cmake edo lua-single
 
 DESCRIPTION="Universal status bar content generator"
 HOMEPAGE="https://github.com/shdown/luastatus"
-
 if [[ ${PV} == *9999* ]]; then
 	inherit git-r3
-	SRC_URI=""
 	EGIT_REPO_URI="https://github.com/shdown/${PN}.git"
-	KEYWORDS="~amd64 ~x86"
 else
 	SRC_URI="https://github.com/shdown/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-	KEYWORDS="amd64 x86"
+	KEYWORDS="~amd64 ~x86"
 fi
-
-BARLIBS="
-	${PN}_barlibs_dwm
-	${PN}_barlibs_i3
-	${PN}_barlibs_lemonbar
-	${PN}_barlibs_stdout
-"
-
-PROPER_PLUGINS="
-	+${PN}_plugins_alsa
-	+${PN}_plugins_dbus
-	+${PN}_plugins_fs
-	+${PN}_plugins_inotify
-	+${PN}_plugins_mpd
-	+${PN}_plugins_network-linux
-	+${PN}_plugins_pulse
-	+${PN}_plugins_timer
-	+${PN}_plugins_udev
-	+${PN}_plugins_unixsock
-	+${PN}_plugins_xkb
-	+${PN}_plugins_xtitle
-"
-
-DERIVED_PLUGINS="
-	+${PN}_plugins_backlight-linux
-	+${PN}_plugins_battery-linux
-	+${PN}_plugins_cpu-usage-linux
-	+${PN}_plugins_file-contents-linux
-	+${PN}_plugins_imap
-	+${PN}_plugins_mem-usage-linux
-	+${PN}_plugins_pipe
-"
-
-PLUGINS="
-	${PROPER_PLUGINS}
-	${DERIVED_PLUGINS}
-"
 
 LICENSE="LGPL-3+"
 SLOT="0"
-IUSE="doc examples luajit ${BARLIBS} ${PLUGINS}"
-REQUIRED_USE="
-	${PN}_plugins_backlight-linux? ( ${PN}_plugins_udev )
-	${PN}_plugins_battery-linux? ( ${PN}_plugins_udev )
-	${PN}_plugins_cpu-usage-linux? ( ${PN}_plugins_timer )
-	${PN}_plugins_file-contents-linux? ( ${PN}_plugins_inotify )
-	${PN}_plugins_imap? ( ${PN}_plugins_timer )
-	${PN}_plugins_mem-usage-linux? ( ${PN}_plugins_timer )
-	${PN}_plugins_pipe? ( ${PN}_plugins_timer )
-"
+IUSE="alsa dbus i3 imap network pulseaudio test udev X"
+REQUIRED_USE="${LUA_REQUIRED_USE}"
+RESTRICT="!test? ( test )"
 
-DEPEND="
-	doc? ( dev-python/docutils )
-"
 RDEPEND="
-	luajit? ( dev-lang/luajit:2 )
-	!luajit? ( dev-lang/lua )
-	${PN}_barlibs_dwm? ( x11-libs/libxcb )
-	${PN}_barlibs_i3? ( >=dev-libs/yajl-2.0.4 )
-	${PN}_plugins_alsa? ( media-libs/alsa-lib )
-	${PN}_plugins_dbus? ( dev-libs/glib )
-	${PN}_plugins_network-linux? ( sys-kernel/linux-headers dev-libs/libnl )
-	${PN}_plugins_pulse? ( media-sound/pulseaudio )
-	${PN}_plugins_udev? ( virtual/libudev )
-	${PN}_plugins_xkb? ( x11-libs/libX11 )
-	${PN}_plugins_xtitle? ( x11-libs/libxcb x11-libs/xcb-util-wm x11-libs/xcb-util )
+	${LUA_DEPS}
+	alsa? ( >=media-libs/alsa-lib-1.0.27.2 )
+	dbus? (
+		>=dev-libs/glib-2.40.2:2[dbus]
+		sys-apps/dbus
+	)
+	i3? ( >=dev-libs/yajl-2.0.4:= )
+	imap? (
+		$(lua_gen_cond_dep '
+			dev-lua/luasec[${LUA_USEDEP}]
+			dev-lua/luasocket[${LUA_USEDEP}]
+		')
+	)
+	network? ( dev-libs/libnl:3 )
+	pulseaudio? ( >=media-libs/libpulse-4.0 )
+	udev? ( >=virtual/libudev-204:= )
+	X? (
+		>=x11-libs/libxcb-1.10:=
+		>=x11-libs/libX11-1.6.2
+		>=x11-libs/xcb-util-wm-0.4.1
+	)
+"
+# linux-headers for inotify and network
+DEPEND="
+	${RDEPEND}
+	sys-kernel/linux-headers
+	X? ( >=x11-libs/xcb-util-0.3.8 )
+"
+BDEPEND="
+	dev-python/docutils
+	virtual/pkgconfig
+	test? (
+		i3? ( app-misc/jq )
+		pulseaudio? ( media-sound/pulseaudio-daemon )
+	)
 "
 
 src_configure() {
 	local mycmakeargs=(
-		$(use luajit && echo -DWITH_LUA_LIBRARY=luajit)
-		-DBUILD_DOCS=$(usex doc)
-		-DBUILD_BARLIB_DWM=$(usex ${PN}_barlibs_dwm)
-		-DBUILD_BARLIB_I3=$(usex ${PN}_barlibs_i3)
-		-DBUILD_BARLIB_LEMONBAR=$(usex ${PN}_barlibs_lemonbar)
-		-DBUILD_BARLIB_STDOUT=$(usex ${PN}_barlibs_stdout)
-		-DBUILD_PLUGIN_ALSA=$(usex ${PN}_plugins_alsa)
-		-DBUILD_PLUGIN_BACKLIGHT_LINUX=$(usex ${PN}_plugins_backlight-linux)
-		-DBUILD_PLUGIN_BATTERY_LINUX=$(usex ${PN}_plugins_battery-linux)
-		-DBUILD_PLUGIN_CPU_USAGE_LINUX=$(usex ${PN}_plugins_cpu-usage-linux)
-		-DBUILD_PLUGIN_DBUS=$(usex ${PN}_plugins_dbus)
-		-DBUILD_PLUGIN_FILE_CONTENTS_LINUX=$(usex ${PN}_plugins_file-contents-linux)
-		-DBUILD_PLUGIN_FS=$(usex ${PN}_plugins_fs)
-		-DBUILD_PLUGIN_IMAP=$(usex ${PN}_plugins_imap)
-		-DBUILD_PLUGIN_INOTIFY=$(usex ${PN}_plugins_inotify)
-		-DBUILD_PLUGIN_MEM_USAGE_LINUX=$(usex ${PN}_plugins_mem-usage-linux)
-		-DBUILD_PLUGIN_MPD=$(usex ${PN}_plugins_mpd)
-		-DBUILD_PLUGIN_NETWORK_LINUX=$(usex ${PN}_plugins_network-linux)
-		-DBUILD_PLUGIN_PIPE=$(usex ${PN}_plugins_pipe)
-		-DBUILD_PLUGIN_PULSE=$(usex ${PN}_plugins_pulse)
-		-DBUILD_PLUGIN_TIMER=$(usex ${PN}_plugins_timer)
-		-DBUILD_PLUGIN_UDEV=$(usex ${PN}_plugins_udev)
-		-DBUILD_PLUGIN_UNIXSOCK=$(usex ${PN}_plugins_unixsock)
-		-DBUILD_PLUGIN_XKB=$(usex ${PN}_plugins_xkb)
-		-DBUILD_PLUGIN_XTITLE=$(usex ${PN}_plugins_xtitle)
+		-DBUILD_TESTS=$(usex test)
+		-DWITH_LUA_LIBRARY=${ELUA}
+
+		-DBUILD_BARLIB_I3=$(usex i3)
+		-DBUILD_BARLIB_DWM=$(usex X)
+
+		-DLUA_PLUGINS_DIR="$(lua_get_lmod_dir)/${PN}/plugins"
+		# handle only plugins with deps, others are enabled by default
+		-DBUILD_PLUGIN_ALSA=$(usex alsa)
+		-DBUILD_PLUGIN_DBUS=$(usex dbus)
+		-DBUILD_PLUGIN_NETWORK_LINUX=$(usex network)
+		-DBUILD_PLUGIN_PULSE=$(usex pulseaudio)
+		-DBUILD_PLUGIN_BACKLIGHT_LINUX=$(usex udev)
+		-DBUILD_PLUGIN_BATTERY_LINUX=$(usex udev)
+		-DBUILD_PLUGIN_UDEV=$(usex udev)
+		-DBUILD_PLUGIN_UNIXSOCK=ON
+		-DBUILD_PLUGIN_XKB=$(usex X)
+		-DBUILD_PLUGIN_XTITLE=$(usex X)
 	)
 	cmake_src_configure
 }
 
+src_test() {
+	local skip_tests=(
+		plugin-mpd # needs server
+		plugin-llamacxx # disabled
+		httpserv # for llamacxx, needs libwebsocket
+		$(usev !dbus plugin-dbus)
+		$(usev !i3 barlib-i3)
+		$(usev !imap plugin-imap)
+		$(usev !network plugin-network-linux)
+		$(usev !pulseaudio plugin-pulse)
+		$(usev !udev plugin-backlight-linux)
+		$(usev !udev plugin-battery-linux)
+	)
+	edo ./tests/pt.sh "${BUILD_DIR}" "${skip_tests[@]/#/skip:}"
+}
+
 src_install() {
 	cmake_src_install
-	local i
-	if use examples; then
-		dodir /usr/share/doc/${PF}/examples
-		docinto examples
-		for i in ${BARLIBS//+/}; do
-			if use ${i}; then
-				barlib=${i#${PN}_barlibs_}
-				dodoc -r examples/${barlib}
-				docompress -x /usr/share/doc/${PF}/examples/${barlib}
-			fi
-		done
-	fi
+
+	dodoc -r examples
+	docompress -x /usr/share/doc/${PF}/examples
 }


### PR DESCRIPTION
Hi, I plan to add luastatus in https://github.com/gentoo/guru
For this, I tried to simplify the ebuild a bit to avoid too many useflags without dependencies.
Tell me what you think about this update. In::guru, it will have more chance to be installed.

use lua-single eclass
useflag only if deps are required
wireup tests
generate manpages unconditionnally
install examples unconditionnally